### PR TITLE
Update Jekyll and GitHub Pages dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ Gemfile.lock
 
 # Sass
 .sass-cache/
+/bin/

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,10 @@
 source "https://rubygems.org"
 
 # Jekyll version compatible with GitHub Pages
-gem "jekyll", "~> 3.9.3"
+gem "jekyll", "~> 3.10.0"
 
 # GitHub Pages gem for local development
-gem "github-pages", "~> 228", group: :jekyll_plugins
+gem "github-pages", "~> 232", group: :jekyll_plugins
 
 # Jekyll plugins
 group :jekyll_plugins do

--- a/_config.yml
+++ b/_config.yml
@@ -37,6 +37,7 @@ author :
   feedburner : feedname
 
 production_url : https://blog.markpearl.co.za
+repository: MarkPearlCoZa/Blog_General
 
 JB :
   version : 0.3.0


### PR DESCRIPTION
- Update github-pages gem from ~228 to ~232
- Update Jekyll from ~3.9.3 to ~3.10.0
- Add repository config to _config.yml for GitHub metadata plugin
- Add /bin/ to .gitignore for bundle binstubs

This brings the blog up to date with the latest GitHub Pages supported versions, ensuring compatibility and access to latest bug fixes and improvements.