### PR TITLE
Fix markdown issues in blog posts

### DIFF
--- a/_posts/2012-01-28-Fix-for-NDbUnit---DbCommandBuilder.CreateSelectCommand(DataSet,-string)-failed-for-tableName-=-XXX.md
+++ b/_posts/2012-01-28-Fix-for-NDbUnit---DbCommandBuilder.CreateSelectCommand(DataSet,-string)-failed-for-tableName-=-XXX.md
@@ -6,7 +6,7 @@ category: Tech
 ---
 I have recently been using NDbUnit for integration tests exercising the database. I am new to the tool, so the following exception caused a few hours of scratching my head before I figured out the obvious.
 
-Assume you are going through the quick start guide from the website, everything works perfectly. Then I changed to my production database and did the same thing and I get the following error…]
+Assume you are going through the quick start guide from the website, everything works perfectly. Then I changed to my production database and did the same thing and I get the following error…
 
 DbCommandBuilder.CreateSelectCommand(DataSet, string) failed for tableName = '….
 

--- a/_posts/2012-01-28-Fix-for-NDbUnit---DbCommandBuilder.CreateSelectCommand(DataSet,-string)-failed-for-tableName-=-XXX.md
+++ b/_posts/2012-01-28-Fix-for-NDbUnit---DbCommandBuilder.CreateSelectCommand(DataSet,-string)-failed-for-tableName-=-XXX.md
@@ -14,15 +14,14 @@ Turns out the name of the table in my database was “My.ExampleTable” with th
 
 The way you can identify this is if you go into Sql Management Studio and look at the Schemas.
 
-Schema
+![Schema]({{ site.url }}/assets/images/NDbUnit-Schema.png)
 
 Pulling the table into the xsd diagram will give you something like the following…
 
-2
-
+![XSD Diagram 1]({{ site.url }}/assets/images/NDbUnit-XSD-1.png)
 
 Adding the first part of the name back to the xsd diagram file solved the problem as illustrated in the last diagram….
 
-3
+![XSD Diagram 2]({{ site.url }}/assets/images/NDbUnit-XSD-2.png)
 
 And that should resolve the error, or at east it did in my case…

--- a/_posts/2016-04-14-Becoming-A-Mobber.md
+++ b/_posts/2016-04-14-Becoming-A-Mobber.md
@@ -9,7 +9,7 @@ category: General
 
 In June 2015 I attended [Agile Roots](http://www.agileroots.com/) - a regional agile conference held in Utah that I highly recommend. While there I had the privilege of spending a day at [Pluralsight](http://www.pluralsight.com/) with one of their engineering teams ([Allan](https://twitter.com/AllanCodes), [Eric](https://twitter.com/iminurcodez) and  [David](https://twitter.com/battenworks)) doing a [team tourism](http://blog.markpearl.co.za/Team-Tourism) day. It was one of the funnest day's I have had in my professional career and while at the time I didn't realize it - I learnt a technique of collaboration that has had a fundamental impact on how I develop software.
 
-<img class="img-responsive" alt="Me with Allan, David & Eric at Pluralsight" src="{{ site.utl }}/assets/images/Becomming-A-Mobber-Pluralsight-Team.jpg">
+<img class="img-responsive" alt="Me with Allan, David & Eric at Pluralsight" src="{{ site.url }}/assets/images/Becomming-A-Mobber-Pluralsight-Team.jpg">
 
 So what did we do? In a nutshell, the four of us stood around a large screen (60") with a single keyboard, working together on a single user story for the entire day. Every ten minutes we would swap who was typing on the keyboard, while those not typing remained engaged in solving the problem by giving their insights. By the end of the day I was thoroughly exhausted but hooked - it was my first introduction to mob programming. 
 

--- a/_posts/2016-04-14-Becoming-A-Mobber.md
+++ b/_posts/2016-04-14-Becoming-A-Mobber.md
@@ -7,7 +7,7 @@ category: General
 
 #### First introduction to mob programming
 
-In June 2015 I attended [Agile Roots](http://www.agileroots.com/) - a regional agile conference held in Utah that I highly recommend. While there I had the privilege of spending a day at [Pluralsight](http://www.pluralsight.com/) with one of their engineering teams ([Allan](https://twitter.com/AllanCodes), [Eric](https://twitter.com/iminurcodez]) and  [David](https://twitter.com/battenworks)) doing a [team tourism](http://blog.markpearl.co.za/Team-Tourism) day. It was one of the funnest day's I have had in my professional career and while at the time I didn't realize it - I learnt a technique of collaboration that has had a fundamental impact on how I develop software.
+In June 2015 I attended [Agile Roots](http://www.agileroots.com/) - a regional agile conference held in Utah that I highly recommend. While there I had the privilege of spending a day at [Pluralsight](http://www.pluralsight.com/) with one of their engineering teams ([Allan](https://twitter.com/AllanCodes), [Eric](https://twitter.com/iminurcodez) and  [David](https://twitter.com/battenworks)) doing a [team tourism](http://blog.markpearl.co.za/Team-Tourism) day. It was one of the funnest day's I have had in my professional career and while at the time I didn't realize it - I learnt a technique of collaboration that has had a fundamental impact on how I develop software.
 
 <img class="img-responsive" alt="Me with Allan, David & Eric at Pluralsight" src="{{ site.utl }}/assets/images/Becomming-A-Mobber-Pluralsight-Team.jpg">
 

--- a/_posts/2017-03-10-Giving-bad-news-notes.md
+++ b/_posts/2017-03-10-Giving-bad-news-notes.md
@@ -27,4 +27,4 @@ We are exceptionally good at this whole avoidance thing.
 
 ## References
 
-[Why saying no thanks is so hard](http://us7.campaign-archive2.com/?u=61b9f569636d0029c60263a99&id=a1b33b7096&e=807b678eab]  
+[Why saying no thanks is so hard](http://us7.campaign-archive2.com/?u=61b9f569636d0029c60263a99&id=a1b33b7096&e=807b678eab)  

--- a/_posts/2017-03-10-Giving-bad-news-notes.md
+++ b/_posts/2017-03-10-Giving-bad-news-notes.md
@@ -15,7 +15,7 @@ We are exceptionally good at this whole avoidance thing.
 * We stick to what we know.  If we believe it won’t matter whether we give the news or not, then we will believe ourselves.
 * We value ourselves over others.  That is, how we feel matters more than getting back to someone else. Ouch!   
 
-## 5 top tips to make it as easy as possible; 
+## 5 top tips to make it as easy as possible: 
 
 1. Preparation is important and doesn’t need to take that much time.  
 2. Ground it in facts and evidence. Give them the detail about why it is a no. You only need 1-2 points to make it valuable feedback.  


### PR DESCRIPTION
## Summary
- Fixed typo in image URL (site.utl → site.url) in Becoming-A-Mobber.md
- Fixed heading punctuation (semicolon → colon) in Giving-bad-news-notes.md  
- Converted broken image references to proper markdown syntax in NDbUnit post
- Fixed malformed markdown link in Becoming-A-Mobber.md
- Fixed malformed markdown link in Giving-bad-news-notes.md

## Test plan
- [ ] Verify all three blog posts render correctly
- [ ] Check that images display properly in the NDbUnit post
- [ ] Confirm markdown syntax is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)